### PR TITLE
add drop = FALSE when reading

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rhdf5
 Type: Package
 Title: HDF5 interface to R
-Version: 2.21.1
+Version: 2.21.1.1
 Author: Bernd Fischer, Gregoire Pau
 Maintainer: Mike Smith <mike.smith@embl.de>
 Description: This R/Bioconductor package provides an interface between HDF5 and R. HDF5's main features are the ability to store and access very large and/or complex datasets and a wide variety of metadata on mass storage (disk) through a completely portable file format. The rhdf5 package is thus suited for the exchange of large and/or complex datasets between R and other software package, and for letting R applications work on datasets that are larger than the available RAM.

--- a/R/H5D.R
+++ b/R/H5D.R
@@ -74,7 +74,7 @@ H5Dget_storage_size <- function( h5dataset ) {
 }
 
 H5Dread <- function( h5dataset, h5spaceFile=NULL, h5spaceMem=NULL, buf = NULL, compoundAsDataFrame = TRUE,
-                     bit64conversion ) {
+                     bit64conversion, drop = FALSE ) {
   h5checktype(h5dataset, "dataset")
   h5checktypeOrNULL(h5spaceFile, "dataspace")
   h5checktypeOrNULL(h5spaceMem, "dataspace")
@@ -90,7 +90,7 @@ H5Dread <- function( h5dataset, h5spaceFile=NULL, h5spaceMem=NULL, buf = NULL, c
       stop("install package 'bit64' before using bit64conversion='bit64'")
     }
   }
-  res <- .Call("_H5Dread", h5dataset@ID, sidFile, sidMem, buf, compoundAsDataFrame, bit64conv, PACKAGE='rhdf5')
+  res <- .Call("_H5Dread", h5dataset@ID, sidFile, sidMem, buf, compoundAsDataFrame, bit64conv, drop, PACKAGE='rhdf5')
   if (H5Aexists(h5obj=h5dataset, name="storage.mode")) {
     att = H5Aopen(h5obj=h5dataset, name="storage.mode")
     if (H5Aread(h5attribute=att) == "logical") {

--- a/R/h5read.R
+++ b/R/h5read.R
@@ -1,5 +1,5 @@
 h5readDataset <- function (h5dataset, index = NULL, start = NULL, stride = NULL, 
-                           block = NULL, count = NULL, compoundAsDataFrame = TRUE, ...) {
+                           block = NULL, count = NULL, compoundAsDataFrame = TRUE, drop = FALSE, ...) {
   try({
     h5spaceFile <- H5Dget_space(h5dataset)
   })
@@ -35,8 +35,8 @@ h5readDataset <- function (h5dataset, index = NULL, start = NULL, stride = NULL,
   obj <- NULL
   try({
     obj <- H5Dread(h5dataset = h5dataset, h5spaceFile = h5spaceFile, 
-                   h5spaceMem = h5spaceMem, compoundAsDataFrame = compoundAsDataFrame, 
-                   ...)
+                   h5spaceMem = h5spaceMem,
+                   compoundAsDataFrame = compoundAsDataFrame, drop = drop, ...)
   })
   if (!is.null(h5spaceMem)) {
     try({
@@ -57,7 +57,7 @@ h5readDataset <- function (h5dataset, index = NULL, start = NULL, stride = NULL,
   obj
 }
 
-h5read <- function(file, name, index=NULL, start=NULL, stride=NULL, block=NULL, count=NULL, compoundAsDataFrame = TRUE, callGeneric = TRUE, read.attributes=FALSE, ... ) {
+h5read <- function(file, name, index=NULL, start=NULL, stride=NULL, block=NULL, count=NULL, compoundAsDataFrame = TRUE, callGeneric = TRUE, read.attributes=FALSE, drop = FALSE, ... ) {
   loc = h5checktypeOrOpenLoc(file, readonly=TRUE)
 
   if (!H5Lexists(loc$H5Identifier, name)) {
@@ -77,7 +77,7 @@ h5read <- function(file, name, index=NULL, start=NULL, stride=NULL, block=NULL, 
       if (type == "H5I_DATASET") {
         try( { h5dataset <- H5Dopen(loc$H5Identifier, name) } )
         obj <- h5readDataset(h5dataset, index = index, start = start, stride = stride, 
-                      block = block, count = count, compoundAsDataFrame = compoundAsDataFrame, ...)
+                      block = block, count = count, compoundAsDataFrame = compoundAsDataFrame, drop = drop, ...)
         try( { H5Dclose(h5dataset) } )
         
         cl <- attr(obj,"class")

--- a/man/H5D.Rd
+++ b/man/H5D.Rd
@@ -23,7 +23,9 @@ H5Dget_space        (h5dataset)
 H5Dget_type         (h5dataset)
 H5Dget_create_plist (h5dataset)
 H5Dget_storage_size (h5dataset)
-H5Dread             (h5dataset, h5spaceFile = NULL, h5spaceMem = NULL, buf = NULL, compoundAsDataFrame = TRUE, bit64conversion)
+H5Dread             (h5dataset, h5spaceFile = NULL, h5spaceMem = NULL,
+                     buf = NULL, compoundAsDataFrame = TRUE,
+                     bit64conversion, drop = FALSE)
 H5Dwrite            (h5dataset, buf, h5spaceMem = NULL, h5spaceFile = NULL)
 H5Dset_extent       (h5dataset, size)
 }
@@ -38,6 +40,7 @@ H5Dset_extent       (h5dataset, size)
   \item{buf}{Reading and writing buffer containing the data to written/read. When using the buffer for reading, the buffer size has to fit the size of the memory space \code{h5spaceMem}. No extra memory will be allocated for the data. A pointer to the same data is returned.}
   \item{compoundAsDataFrame}{If true, a compound datatype will be coerced to a data.frame. This is not possible, if the dataset is multi-dimensional. Otherwise the compound datatype will be returned as a list. Nested compound data types will be returned as a nested list.}
   \item{bit64conversion}{Defines, how 64-bit integers are converted. Internally, R does not support 64-bit integers. All integers in R are 32-bit integers. By setting bit64conversion='int', a coercing to 32-bit integers is enforced, with the risc of data loss, but with the insurance that numbers are represented as integers. bit64conversion='double' coerces the 64-bit integers to floating point numbers. doubles can represent integers with up to 54-bits, but they are not represented as integer values anymore. For larger numbers there is again a data loss. bit64conversion='bit64' is recommended way of coercing. It represents the 64-bit integers as objects of class 'integer64' as defined in the package 'bit64'. Make sure that you have installed 'bit64'. The datatype 'integer64' is not part of base R, but defined in an external package. This can produce unexpected behaviour when working with the data.}
+  \item{drop}{(logical) If TRUE, the HDF5 object is read as a vector with NULL dim attributes.}
   \item{size}{An integer vector with the new dimension of the dataset. Calling this function is only valid for chunked datasets.}
   \item{lcpl}{An object of class \code{\link{H5IdComponent}} representing a H5 link creation property list. See \code{\link{H5Pcreate}}, \code{\link{H5Pcopy}} to create an object of this kind.}
   \item{dcpl}{An object of class \code{\link{H5IdComponent}} representing a H5 dataset creation property list. See \code{\link{H5Pcreate}}, \code{\link{H5Pcopy}} to create an object of this kind.}

--- a/man/h5write.Rd
+++ b/man/h5write.Rd
@@ -28,7 +28,7 @@ Reads and writes objects in HDF5 files. This function can be used to read and wr
 h5read                      (file, name, index=NULL,
                              start=NULL, stride=NULL, block=NULL, count=NULL,
                              compoundAsDataFrame = TRUE, callGeneric = TRUE,
-			     read.attributes = FALSE, ...)
+			     read.attributes = FALSE, drop = FALSE, ...)
 h5readAttributes            (file, name)
 h5write                     (obj, file, name, ...)
 h5write.default             (obj, file, name, 
@@ -73,6 +73,7 @@ h5writeAttribute.array      (attr, h5obj, name, size)
   \item{size}{The length of string data type. Variable lengt strings are not yet supported.}
   \item{createnewfile}{If TRUE, a new file will be created if necessary.}
   \item{read.attributes}{(logical) If TRUE, the HDF5 attributes are read and attached to the respective R object.}
+  \item{drop}{(logical) If TRUE, the HDF5 object is read as a vector with NULL dim attributes.}
   \item{write.attributes}{(logical) If TRUE, all R-attributes attached to the object \code{obj} are written to the HDF5 file.}
   \item{\dots}{Further arguments passed to \code{\link{H5Dread}}.}
 }

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -783,8 +783,9 @@ SEXP H5Dread_helper(hid_t dataset_id, hid_t file_space_id, hid_t mem_space_id, h
 /* herr_t H5Dread(hid_t dataset_id, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id, hid_t xfer_plist_id, void * buf ) */
 /* TODO: accept mem_type_id as parameter */
 SEXP _H5Dread( SEXP _dataset_id, SEXP _file_space_id, SEXP _mem_space_id, SEXP _buf, SEXP _compoundAsDataFrame,
-               SEXP _bit64conversion  ) {
+               SEXP _bit64conversion, SEXP _drop  ) {
   int compoundAsDataFrame = LOGICAL(_compoundAsDataFrame)[0];
+  int drop = LOGICAL(_drop)[0];
   int bit64conversion = INTEGER(_bit64conversion)[0];
 
   /***********************************************************************/
@@ -841,7 +842,7 @@ SEXP _H5Dread( SEXP _dataset_id, SEXP _file_space_id, SEXP _mem_space_id, SEXP _
     n = n * size[i];
   }
   SEXP Rdim;
-  if (rank > 0) {
+  if (!drop && rank > 0) {
     Rdim = PROTECT(allocVector(INTSXP, rank));
     for (int i=0; i<rank; i++) {
       INTEGER(Rdim)[rank-i-1] = size[i];
@@ -860,7 +861,7 @@ SEXP _H5Dread( SEXP _dataset_id, SEXP _file_space_id, SEXP _mem_space_id, SEXP _
   if (length(_mem_space_id) == 0) {
     H5Sclose(mem_space_id);
   }
-  if (rank > 0) {
+  if (!drop && rank > 0) {
     UNPROTECT(1);
   }
 

--- a/src/H5D.h
+++ b/src/H5D.h
@@ -54,7 +54,7 @@ SEXP H5Dread_helper(hid_t dataset_id, hid_t file_space_id, hid_t mem_space_id, h
 		    hid_t cpdType, int cpdNField, char ** cpdField, int compoundAsDataFrame,
                     int bit64conversion );
 SEXP _H5Dread( SEXP _dataset_id, SEXP _file_space_id, SEXP _mem_space_id, SEXP _buf, SEXP _compoundAsDataFrame,
-               SEXP _bit64conversion );
+               SEXP _bit64conversion, SEXP _drop );
 SEXP _H5Dwrite( SEXP _dataset_id, SEXP _buf, SEXP _file_space_id, SEXP _mem_space_id );
 /* H5Diterate */
 

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -53,7 +53,7 @@ static R_CallMethodDef libraryRCalls[] = {
   {"_H5Dget_space", (DL_FUNC) &_H5Dget_space, 1},
   {"_H5Dget_storage_size", (DL_FUNC) &_H5Dget_space, 1},
   {"_create_Integer_test_file", (DL_FUNC) &_create_Integer_test_file, 0},
-  {"_H5Dread", (DL_FUNC) &_H5Dread, 6},
+  {"_H5Dread", (DL_FUNC) &_H5Dread, 7},
   {"_H5Dwrite", (DL_FUNC) &_H5Dwrite, 4},
   {"_H5Dset_extent", (DL_FUNC) &_H5Dset_extent, 2},
   {"_H5Fcreate", (DL_FUNC) &_H5Fcreate, 4},


### PR DESCRIPTION
- drop = TRUE does not set dim attribute, allowing n x 1 arrays (which
  are not allowed when n > 2^31 - 1) to be represented as vector(n)