### PR TITLE
allow custom HDF5 data types in h5createDataset and h5writeDataset

### DIFF
--- a/R/h5create.R
+++ b/R/h5create.R
@@ -117,13 +117,17 @@ h5createGroup <- function(file, group) {
                       H5Tset_cset(tid, encoding)
                       tid
                     },
-                    { stop("datatype ",storage.mode, " not yet implemented.\n", 
+                    { stop("datatype ",storage.mode, " not yet implemented.\n",
                            "Try 'logical', 'double', 'integer', 'integer64' or 'character'.") } )
     } else {
       stop("Can not create dataset. 'storage.mode' has to be a character.")
     }
-  } else {
+  } else if (!grepl("^\\d+$", H5type)) {
     tid <- h5checkConstants("H5T", H5type)
+  } else if (!tryCatch(H5Tget_precision(H5type), error=\(...) FALSE)) {
+     tid <- NA
+  } else {
+      tid <- H5type
   }
   if (is.na(tid)) {
     stop("Can not create dataset. H5type unknown. Check h5const('H5T') for valid types.")
@@ -289,7 +293,8 @@ h5createGroup <- function(file, group) {
 #' @param H5type Advanced programmers can specify the datatype of the dataset
 #'   within the file. See \code{h5const("H5T")} for a list of available
 #'   datatypes. If \code{H5type} is specified the argument \code{storage.mode}
-#'   is ignored. It is recommended to use \code{storage.mode}
+#'   is ignored. It is recommended to use \code{storage.mode}. \code{H5type}
+#'   can also be the ID of a created datatype, e.g. with [H5Tenum_create].
 #' @param size For `storage.mode='character'` the maximum string length to use.
 #'   The default value of `NULL` will result in using variable length strings.
 #'   See the details for more information on this option.

--- a/man/h5_createDataset.Rd
+++ b/man/h5_createDataset.Rd
@@ -48,7 +48,8 @@ obtained by \code{storage.mode(mydata)}.}
 \item{H5type}{Advanced programmers can specify the datatype of the dataset
 within the file. See \code{h5const("H5T")} for a list of available
 datatypes. If \code{H5type} is specified the argument \code{storage.mode}
-is ignored. It is recommended to use \code{storage.mode}}
+is ignored. It is recommended to use \code{storage.mode}. \code{H5type}
+can also be the ID of a created datatype, e.g. with \link{H5Tenum_create}.}
 
 \item{size}{For \code{storage.mode='character'} the maximum string length to use.
 The default value of \code{NULL} will result in using variable length strings.
@@ -172,9 +173,9 @@ h5createFile(f2)
 
 ## create two string datasets
 ## the first is variable length strings, the second fixed at the length of our longest word
-h5createDataset(f1, "strings", dims = length(words), storage.mode = "character", 
+h5createDataset(f1, "strings", dims = length(words), storage.mode = "character",
                 size = NULL, chunk = 25)
-h5createDataset(f2, "strings", dims = length(words), storage.mode = "character", 
+h5createDataset(f2, "strings", dims = length(words), storage.mode = "character",
                 size = max(nchar(words)), chunk = 25)
 
 ## Write the data

--- a/man/h5_write.Rd
+++ b/man/h5_write.Rd
@@ -37,7 +37,8 @@ h5writeDataset(obj, h5loc, name, ...)
   size = NULL,
   variableLengthString = FALSE,
   encoding = NULL,
-  level = 6
+  level = 6,
+  h5type = NULL
 )
 }
 \arguments{
@@ -118,6 +119,11 @@ variable-length strings into the attributes. If \code{TRUE}, \code{size} is igno
 
 \item{encoding}{The encoding of the string data type.  Valid options are
 "ASCII" or "UTF-8".}
+
+\item{h5type}{(character) Datatype of the dataset to be written. See
+\code{h5const("H5T")} for a list of available datatypes. Alternatively,
+\code{h5type} can be the ID of a created datatype, e.g. with
+\link{H5Tenum_create}. If \code{NULL}, it will use the datatype of the R object.}
 }
 \value{
 \code{h5write} returns 0 if successful.


### PR DESCRIPTION
This useful when one has a custom type, but still wants to use the default HDF5 spaces, DCPLs etc. that these functions provide. For example, when writing logical vectors that are compatible with Python's h5py, one needs to create a custom enum type with `H5Tenum_create`.