### PR TITLE
Address integer overflow in H5Screate_simple()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,4 +33,4 @@ SystemRequirements: GNU make
 biocViews: Infrastructure, DataImport
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/R/H5S.R
+++ b/R/H5S.R
@@ -29,9 +29,9 @@ H5Screate <- function( type = h5default("H5S"), native = FALSE ) {
 
 #' Create a simple dataspace
 #'
-#' @param dims An integer vector defining the initial dimensions of the dataspace.
+#' @param dims A numeric vector defining the initial dimensions of the dataspace.
 #' The length of `dims` determines the rank of the dataspace.
-#' @param maxdims An integer vector with the same length length as `dims`.  Specifies the 
+#' @param maxdims A numeric vector with the same length length as `dims`.  Specifies the
 #' upper limit on the size of the dataspace dimensions.  Only needs to be specified
 #' if this is different from the values given to `dims`.
 #' @param native An object of class `logical`. If `TRUE`, array-like
@@ -47,11 +47,12 @@ H5Screate <- function( type = h5default("H5S"), native = FALSE ) {
 #'
 #' @export
 H5Screate_simple <- function( dims, maxdims, native = FALSE ) {
+  dims <- as.numeric(dims)
   if (missing(maxdims)) {
-    maxdims = dims
+    maxdims <- dims
+  } else {
+    maxdims <- as.numeric(maxdims)
   }
-  dims <- as.integer(dims)
-  maxdims <- as.integer(maxdims)
   if (!native) {
     dims <- rev(dims)
     maxdims <- rev(maxdims)

--- a/man/H5Screate_simple.Rd
+++ b/man/H5Screate_simple.Rd
@@ -7,10 +7,10 @@
 H5Screate_simple(dims, maxdims, native = FALSE)
 }
 \arguments{
-\item{dims}{An integer vector defining the initial dimensions of the dataspace.
+\item{dims}{A numeric vector defining the initial dimensions of the dataspace.
 The length of \code{dims} determines the rank of the dataspace.}
 
-\item{maxdims}{An integer vector with the same length length as \code{dims}.  Specifies the
+\item{maxdims}{A numeric vector with the same length length as \code{dims}.  Specifies the
 upper limit on the size of the dataspace dimensions.  Only needs to be specified
 if this is different from the values given to \code{dims}.}
 

--- a/man/rhdf5.Rd
+++ b/man/rhdf5.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/Rhdf5.R
 \docType{package}
 \name{rhdf5}
+\alias{rhdf5-package}
 \alias{rhdf5}
 \title{rhdf5: An interface between HDF5 and R}
 \description{
@@ -10,4 +11,28 @@ The rhdf5 package provides two categories of functions:
 \item \code{h5} functions are high-level R functions that provide a convenient way of accessing HDF5 files
 \item \code{H5} functions mirror much of the the HDF5 C API
 }
+}
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/grimbough/rhdf5}
+  \item Report bugs at \url{https://github.com/grimbough/rhdf5/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Mike Smith \email{mike.smith@embl.de} (\href{https://orcid.org/0000-0002-7800-3848}{ORCID})
+
+Authors:
+\itemize{
+  \item Bernd Fischer
+  \item Gregoire Pau
+}
+
+Other contributors:
+\itemize{
+  \item Martin Morgan [contributor]
+  \item Daniel van Twisk [contributor]
+}
+
 }

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -45,7 +45,7 @@ SEXP _H5Screate_simple( SEXP _dims, SEXP _maxdims ) {
     int rank = length(_dims);
     hsize_t dims[rank];
     for (int i=0; i<rank; i++) {
-        dims[i] = (hsize_t) INTEGER(_dims)[i];
+        dims[i] = (hsize_t) REAL(_dims)[i];
     }
     if (length(_maxdims) == 0) {
         hid = H5Screate_simple( rank, dims, NULL);
@@ -57,8 +57,10 @@ SEXP _H5Screate_simple( SEXP _dims, SEXP _maxdims ) {
         } else {
             hsize_t maxdims[rank];
             for (int i=0; i<rank; i++) {
-                maxdims[i] = (hsize_t) INTEGER(_maxdims)[i];
+                maxdims[i] = (hsize_t) REAL(_maxdims)[i];
                 // We explicitly use -1 to represent unlimited dimensions
+                /* NOTE (H.P. 2024/2/16): 'maxdims' contains unsigned
+                   values (hsize_t) so this comparison will always be false. */
                 if(maxdims[i] == -1) {
                   maxdims[i] = H5S_UNLIMITED;
                 }


### PR DESCRIPTION
Hi Mike,

When trying to create a 1D dataset with an extension > `.Machine$integer.max`, I get the following warning:
```
library(rhdf5)
h5createFile("test.h5")
h5createDataset("test.h5", "test", dims=0, maxdims=3e9)
# Warning message:
# In H5Screate_simple(dims, maxdims) :
#   NAs introduced by coercion to integer range
```
The warning is coming from `H5Screate_simple()`:
```
sid <- H5Screate_simple(dims=0, maxdims=3e9)
# Warning message:
# In H5Screate_simple(dims = 0, maxdims = 3e+09) :
#   NAs introduced by coercion to integer range

sid
# HDF5 DATASPACE
#         rank 1
#         size 0
#      maxsize 18446744071562067968
```
This PR addresses this by coercing the supplied `dims` or `maxdims` vectors to numeric instead of integer, and by turning the numeric values to `hsize_t` values at the C-level.

With this change:
```
sid <- H5Screate_simple(dims=0, maxdims=3e9)
sid
# HDF5 DATASPACE 
#         rank 1
#         size 0
#      maxsize 3e+09
```

H.