### PR TITLE
Remove outbuf_size

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Depends:
     methods,
     R (>= 4.0.0)
 Imports: 
-    rhdf5filters (>= 1.15.5),
+    rhdf5filters (>= 1.25.4),
     Rhdf5lib (>= 1.33.3)
 Suggests: 
     bench,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rhdf5
 Title: R Interface to HDF5
-Version: 2.57.4
+Version: 2.57.5
 Authors@R: c(
     person("Bernd", "Fischer", role = "aut"),
     person("Mike", "Smith", role = "aut",

--- a/R/H5P_extras.R
+++ b/R/H5P_extras.R
@@ -60,12 +60,10 @@ H5Pset_blosc <- function(
   ## contains a call to blosc_set_local() which determines chunk size & blosc
   ## parameters. This requires calls to HDF5 functions and doesn't play well
   ## with our static linking.  We move this setup code into R code below.
-  chunkdims <- H5Pget_chunk(h5plist)
   typesize <- H5Tget_size(h5tid)
   if (typesize > 255) {
     typesize <- 1
   }
-  bufsize <- typesize * prod(chunkdims)
   ## END
 
   h5checktypeAndPLC(h5plist, "H5P_DATASET_CREATE")
@@ -76,7 +74,6 @@ H5Pset_blosc <- function(
     as.integer(level),
     as.integer(as.logical(shuffle)),
     as.integer(typesize),
-    as.integer(bufsize),
     PACKAGE = "rhdf5"
   )
   invisible(res)
@@ -95,22 +92,10 @@ H5Pset_lzf <- function(h5plist, h5tid) {
       "LZF filter not found.\nPlease install rhdf5filters, and then reinstall rhdf5."
     )
   }
-
-  ## START: simplified reimplementation of C code from lzf_filter.c
-  ## Filter from h5py
-  ## contains a call to lzf_set_local() which determines chunk size
-  ## This requires calls to HDF5 functions and doesn't play well
-  ## with our static linking.  We move this setup code into R code below.
-  chunkdims <- H5Pget_chunk(h5plist)
-  typesize <- H5Tget_size(h5tid)
-  bufsize <- typesize * prod(chunkdims)
-  ## END
-
   h5checktypeAndPLC(h5plist, "H5P_DATASET_CREATE")
   res <- .Call(
     "_H5Pset_lzf",
     h5plist@ID,
-    as.integer(bufsize),
     PACKAGE = "rhdf5"
   )
   invisible(res)

--- a/R/H5P_extras.R
+++ b/R/H5P_extras.R
@@ -61,8 +61,10 @@ H5Pset_blosc <- function(
   ## parameters. This requires calls to HDF5 functions and doesn't play well
   ## with our static linking.  We move this setup code into R code below.
   typesize <- H5Tget_size(h5tid)
-  if (typesize > 255) {
-    typesize <- 1
+  if (is.null(typesize) || typesize > 255) {
+    # NULL happens for variable length types.
+    # See https://github.com/Huber-group-EMBL/rhdf5/issues/168#issuecomment-5168440454
+    typesize <- 1L
   }
   ## END
 
@@ -73,7 +75,7 @@ H5Pset_blosc <- function(
     as.integer(method) - 1L,
     as.integer(level),
     as.integer(as.logical(shuffle)),
-    as.integer(typesize),
+    typesize,
     PACKAGE = "rhdf5"
   )
   invisible(res)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -33,6 +33,9 @@
       when the \code{drop} argument in \code{H5Dread()} is set to \code{TRUE}.
       \item \code{native = TRUE} now works correctly on large arrays with more
       than 2^31-1 elements.
+      \item BLOSC and LZF compression no longer fail when applied to variable
+      length types. Thanks to Luke Zappia for the report and reproducible
+      example.
     }
   }
 
@@ -45,7 +48,12 @@
   \subsection{Internal changes}{
     \itemize{
       \item Compiler warnings and C linting issues have been resolved.
-      \item C code formatting has been standardized with clang-format
+      \item C code formatting has been standardized with clang-format.
+      \item The output buffer size is no longer guessed for BLOSC and LZF
+      compression. This was virtually not used in rhdf5filters already and led
+      to unnecessary complexity in both packages. This was also the source of
+      the bug related to compression of variable length types whose fix is 
+      documented above.
     }
   }
 }

--- a/src/external_filters.c
+++ b/src/external_filters.c
@@ -18,37 +18,35 @@ SEXP _H5Pset_bzip2(SEXP _plist_id, SEXP _level) {
 }
 
 SEXP _H5Pset_blosc(SEXP _plist_id, SEXP _method, SEXP _level, SEXP _shuffle,
-                   SEXP _typesize, SEXP _buffersize) {
+                   SEXP _typesize) {
 
   herr_t herr;
-  unsigned int cd_values[7];
+  unsigned int cd_values[6];
 
   hid_t plist_id = STRSXP_2_HID(_plist_id);
   cd_values[0] = 2; // H5Z_FILTER_BLOSC_VERSION;
   cd_values[1] = 2; // BLOSC_VERSION_FORMAT
   cd_values[2] = INTEGER(_typesize)[0];
-  cd_values[3] = INTEGER(_buffersize)[0];
-  cd_values[4] = INTEGER(_level)[0];   // compression level
-  cd_values[5] = INTEGER(_shuffle)[0]; // shuffle yes/no
-  cd_values[6] = INTEGER(_method)[0];  // compression algorithm
-  herr = H5Pset_filter(plist_id, H5Z_FILTER_BLOSC, H5Z_FLAG_OPTIONAL, (size_t)7,
+  cd_values[3] = INTEGER(_level)[0];   // compression level
+  cd_values[4] = INTEGER(_shuffle)[0]; // shuffle yes/no
+  cd_values[5] = INTEGER(_method)[0];  // compression algorithm
+  herr = H5Pset_filter(plist_id, H5Z_FILTER_BLOSC, H5Z_FLAG_OPTIONAL, (size_t)6,
                        cd_values);
   SEXP Rval = ScalarInteger(herr);
 
   return Rval;
 }
 
-SEXP _H5Pset_lzf(SEXP _plist_id, SEXP _buffersize) {
+SEXP _H5Pset_lzf(SEXP _plist_id) {
 
   herr_t herr;
-  unsigned int cd_values[3];
+  unsigned int cd_values[2];
 
   hid_t plist_id = STRSXP_2_HID(_plist_id);
   cd_values[0] = 32000;
   cd_values[1] = 4;
-  cd_values[2] = INTEGER(_buffersize)[0];
 
-  herr = H5Pset_filter(plist_id, H5Z_FILTER_LZF, H5Z_FLAG_OPTIONAL, (size_t)3,
+  herr = H5Pset_filter(plist_id, H5Z_FILTER_LZF, H5Z_FLAG_OPTIONAL, (size_t)2,
                        cd_values);
   SEXP Rval = ScalarInteger(herr);
 

--- a/src/external_filters.h.in
+++ b/src/external_filters.h.in
@@ -12,7 +12,7 @@
 #define H5Z_FILTER_LZF 32000
 
 SEXP _H5Pset_bzip2( SEXP _plist_id, SEXP _level );
-SEXP _H5Pset_blosc( SEXP _plist_id, SEXP _method, SEXP _level, SEXP _shuffle, SEXP _typesize, SEXP _buffersize );
-SEXP _H5Pset_lzf( SEXP _plist_id, SEXP _buffersize );
+SEXP _H5Pset_blosc( SEXP _plist_id, SEXP _method, SEXP _level, SEXP _shuffle, SEXP _typesize );
+SEXP _H5Pset_lzf( SEXP _plist_id );
 
 #endif

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -377,9 +377,9 @@ static R_CallMethodDef libraryRCalls[] = {
     {"_H5PLget", (DL_FUNC)&_H5PLget, 1},
     {"_h5getAllChunkInfo", (DL_FUNC)&_h5getAllChunkInfo, 1},
 #ifdef _H5P_filters
-    {"_H5Pset_lzf", (DL_FUNC)&_H5Pset_lzf, 2},
+    {"_H5Pset_lzf", (DL_FUNC)&_H5Pset_lzf, 1},
     {"_H5Pset_bzip2", (DL_FUNC)&_H5Pset_bzip2, 2},
-    {"_H5Pset_blosc", (DL_FUNC)&_H5Pset_blosc, 6},
+    {"_H5Pset_blosc", (DL_FUNC)&_H5Pset_blosc, 5},
 #endif
     {NULL, NULL, 0}};
 

--- a/tests/testthat/test_external_filters.R
+++ b/tests/testthat/test_external_filters.R
@@ -3,6 +3,7 @@ library(rhdf5)
 h5File <- withr::local_tempfile(pattern = "ex_save", fileext = ".h5")
 vec <- as.integer(rexp(2000, rate = 1.5))
 
+
 ############################################################
 context("Writing Using External Filters")
 ############################################################
@@ -87,5 +88,67 @@ test_that("LZF filter works when reading", {
 })
 
 H5Fclose(fid)
+
+vlen <- c("this", "is", "a", "variable", "length", "string", "vector", "!!!!!")
+
+test_that("BLOSC works with variable length types", {
+  # https://github.com/Huber-group-EMBL/rhdf5/issues/168#issuecomment-5168440454
+  skip_if_not_installed("rhdf5filters")
+  h5f <- H5Fcreate(tempfile())
+  expect_silent(
+    h5createDataset(
+      h5f,
+      dataset = "blosc_vlen",
+      dims = length(vlen),
+      storage.mode = "character",
+      filter = "BLOSC_ZLIB"
+    )
+  )
+  expect_silent(
+    h5write(
+      vlen,
+      h5f,
+      "blosc_vlen"
+    )
+  )
+  expect_silent(
+    vlen_read <- h5read(
+      h5f,
+      "blosc_vlen"
+    )
+  )
+  expect_equal(vlen, vlen_read, check.attributes = FALSE)
+  H5Fclose(h5f)
+})
+
+test_that("LZF works with variable length types", {
+  # https://github.com/Huber-group-EMBL/rhdf5/issues/168
+  skip_if_not_installed("rhdf5filters")
+  h5f <- H5Fcreate(tempfile())
+  expect_silent(
+    h5createDataset(
+      h5f,
+      dataset = "lzf_vlen",
+      dims = length(vlen),
+      storage.mode = "character",
+      filter = "LZF"
+    )
+  )
+  expect_silent(
+    h5write(
+      vlen,
+      h5f,
+      "lzf_vlen"
+    )
+  )
+  expect_silent(
+    vlen_read <- h5read(
+      h5f,
+      "lzf_vlen"
+    )
+  )
+  expect_equal(vlen, vlen_read, check.attributes = FALSE)
+  H5Fclose(h5f)
+})
 
 h5closeAll()


### PR DESCRIPTION
This parameter is unused / always overwritten for BLOSC and unnecessary for LZF. It is easier to remove it to simplify our code both here and in rhdf5filters, and to avoid issues such as https://github.com/Huber-group-EMBL/rhdf5/issues/168 when we cannot compute outbuf_size properly (VLEN types).

Linked to https://github.com/Huber-group-EMBL/rhdf5filters/pull/37