### PR TITLE
Allow reading and writing NA in VLen strings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rhdf5
 Title: R Interface to HDF5
-Version: 2.57.9
+Version: 2.57.10
 Authors@R: c(
     person("Bernd", "Fischer", role = "aut"),
     person("Mike", "Smith", role = "aut",

--- a/R/h5read.R
+++ b/R/h5read.R
@@ -20,7 +20,9 @@
       }
     }
   } else if (storage.mode(obj) == "character") {
-    ## coerce the string "NA" to NA if required
+    # This is the old way of storing NA values in character datasets (as "NA"
+    # with a special attribute). It is now deprecated and no new datasets
+    # should be written this way. However, we still need to support reading.
     if (H5Aexists(h5dataset, name = "as.na")) {
       obj[obj == "NA"] <- NA_character_
     }

--- a/R/h5write.R
+++ b/R/h5write.R
@@ -162,9 +162,9 @@ h5writeDatasetHelper <- function(
 #'   reading is required, `DataFrameAsCompound=FALSE` is recommended.
 #' @param size The length of the fixed-width string data type, when `obj` is a
 #'   character vector. If `NULL`, this is set to the length of the largest
-#'   string.
+#'   string. Ignored when `variableLengthString=TRUE`.
 #' @param variableLengthString Whether character vectors should be written as
-#'   variable-length strings into the attributes. If `TRUE`, `size` is ignored.
+#'   variable-length strings. If `TRUE` (the default), `size` is ignored.
 #' @param encoding The encoding of the string data type.  Valid options are
 #'   "ASCII" or "UTF-8".
 #' @param createnewfile If `TRUE`, a new file will be created if necessary.
@@ -382,7 +382,7 @@ h5writeDataset.array <- function(
   block = NULL,
   count = NULL,
   size = NULL,
-  variableLengthString = FALSE,
+  variableLengthString = TRUE,
   encoding = NULL,
   level = 6,
   ...

--- a/R/h5write.R
+++ b/R/h5write.R
@@ -393,6 +393,14 @@ h5writeDataset.array <- function(
   })
   if (!exists) {
     if (storage.mode(obj) == "character") {
+      if (!variableLengthString && anyNA(obj)) {
+        warning(
+          "Writing NA_character_ in fixed-length string datasets is fragile ",
+          "and deprecated. ",
+          "Use `variableLengthString=TRUE` to write the data as ",
+          "variable-length strings instead."
+        )
+      }
       if (!variableLengthString && is.null(size)) {
         if (length(obj) > 0) {
           size <- max(nchar(obj, type = "bytes"), na.rm = TRUE)

--- a/R/h5write.R
+++ b/R/h5write.R
@@ -403,6 +403,12 @@ h5writeDataset.array <- function(
           "variable-length strings instead."
         )
       }
+      if (variableLengthString && !is.null(size)) {
+        warning(
+          "Argument `size` is ignored when `variableLengthString=TRUE`."
+        )
+        size <- NULL
+      }
       if (!variableLengthString && is.null(size)) {
         if (length(obj) > 0) {
           size <- max(nchar(obj, type = "bytes"), na.rm = TRUE)

--- a/R/h5write.R
+++ b/R/h5write.R
@@ -396,7 +396,9 @@ h5writeDataset.array <- function(
       if (!variableLengthString && anyNA(obj)) {
         warning(
           "Writing NA_character_ in fixed-length string datasets is fragile ",
-          "and deprecated. ",
+          "and deprecated.\n",
+          "In particular, it will write NA_character_ as the string 'NA' in ",
+          "the HDF5 file.\n",
           "Use `variableLengthString=TRUE` to write the data as ",
           "variable-length strings instead."
         )
@@ -447,16 +449,6 @@ h5writeDataset.array <- function(
     count = count
   )
   h5writeAttribute(1L, h5dataset, name = "rhdf5-NA.OK")
-
-  if (storage.mode(obj) == "character" && anyNA(obj)) {
-    h5writeAttribute(1L, h5dataset, name = "as.na")
-    if (any(obj == "NA", na.rm = TRUE)) {
-      warning(
-        "Both NA_character_ and the string 'NA' detected.\n",
-        "These will all be coerced to NA_character_ when read using h5read()"
-      )
-    }
-  }
 
   invisible(NULL)
 }

--- a/R/h5writeAttr.R
+++ b/R/h5writeAttr.R
@@ -46,7 +46,7 @@ h5writeAttribute <- function(
   name,
   h5loc,
   encoding = NULL,
-  variableLengthString = FALSE,
+  variableLengthString = TRUE,
   asScalar = FALSE,
   checkForNA = TRUE
 ) {
@@ -98,7 +98,7 @@ h5writeAttribute.array <- function(
   name,
   h5loc,
   encoding = NULL,
-  variableLengthString = FALSE,
+  variableLengthString = TRUE,
   asScalar = FALSE,
   checkForNA = TRUE
 ) {

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -13,6 +13,9 @@
       \code{addr} (file byte offsets), and \code{size} (compressed chunk 
       sizes). Requires chunked storage; contiguous datasets raise an error
       Thanks to PR #217 from Michael Sumner (https://github.com/mdsumner).
+      \item Variable length string datasets now support writing and reading
+      \code{NA_character_} values. These values will be read as the empty
+      string \code{""} in Python.
     }
   }
 
@@ -26,6 +29,12 @@
       after being deprecated in version 2.56.0.
       \item The `h5tid` argument to `H5Pset_lzf()` is now deprecated and will
       be removed in the next release.
+      \item Writing `NA_character_` values to fixed-length string datasets is
+      now deprecated and will be removed in a future release.
+      \item Variable length strings is now the default behavior for 
+      `h5write()`, `h5writeDataset()` and `h5writeAttribute()`. This makes them
+      consistent with the behaviour of `h5create()`, `h5createDataset()` and 
+      `h5createAttribute()`.
     }
   }
 
@@ -38,6 +47,9 @@
       \item BLOSC and LZF compression no longer fail when applied to variable
       length types. Thanks to Luke Zappia for the report and reproducible
       example.
+      \item \code{h5write(variableLengthString = TRUE)} now properly ignores
+      the \code{size} argument, as already documented, instead of incorrectly
+      writing a fixed-length string dataset.
     }
   }
 

--- a/man/h5_write.Rd
+++ b/man/h5_write.Rd
@@ -43,7 +43,7 @@ h5writeDataset(obj, h5loc, name, ...)
   block = NULL,
   count = NULL,
   size = NULL,
-  variableLengthString = FALSE,
+  variableLengthString = TRUE,
   encoding = NULL,
   level = 6,
   ...
@@ -120,10 +120,10 @@ index is not NULL.}
 
 \item{size}{The length of the fixed-width string data type, when \code{obj} is a
 character vector. If \code{NULL}, this is set to the length of the largest
-string.}
+string. Ignored when \code{variableLengthString=TRUE}.}
 
 \item{variableLengthString}{Whether character vectors should be written as
-variable-length strings into the attributes. If \code{TRUE}, \code{size} is ignored.}
+variable-length strings. If \code{TRUE} (the default), \code{size} is ignored.}
 
 \item{encoding}{The encoding of the string data type.  Valid options are
 "ASCII" or "UTF-8".}

--- a/man/h5_writeAttribute.Rd
+++ b/man/h5_writeAttribute.Rd
@@ -12,7 +12,7 @@ h5writeAttribute(
   name,
   h5loc,
   encoding = NULL,
-  variableLengthString = FALSE,
+  variableLengthString = TRUE,
   asScalar = FALSE,
   checkForNA = TRUE
 )
@@ -23,7 +23,7 @@ h5writeAttribute(
   name,
   h5loc,
   encoding = NULL,
-  variableLengthString = FALSE,
+  variableLengthString = TRUE,
   asScalar = FALSE,
   checkForNA = TRUE
 )

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -486,7 +486,11 @@ SEXP H5Dread_helper_STRING(hid_t dataset_id, hid_t file_space_id,
         error("Unable to read dataset");
       }
       for (hsize_t i = 0; i < n; i++) {
-        SET_STRING_ELT(Rval, i, mkChar(bufSTR[i]));
+        if (bufSTR[i] == NULL) {
+          SET_STRING_ELT(Rval, i, NA_STRING);
+        } else {
+          SET_STRING_ELT(Rval, i, mkChar(bufSTR[i]));
+        }
       }
       herr = H5Treclaim(mem_type_id, file_space_id, H5P_DEFAULT, bufSTR);
       if (herr < 0) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -114,7 +114,11 @@ void *read_string_datatype(hid_t mem_type_id, SEXP _buf) {
   } else {
     const char **strbuf = (const char **)R_alloc(n, sizeof(char *));
     for (R_xlen_t i = 0; i < n; i++) {
-      strbuf[i] = CHAR(STRING_ELT(_buf, i));
+      if (STRING_ELT(_buf, i) == NA_STRING) {
+        strbuf[i] = NULL;
+      } else {
+        strbuf[i] = CHAR(STRING_ELT(_buf, i));
+      }
     }
     return strbuf;
   }

--- a/tests/testthat/test_h5read.R
+++ b/tests/testthat/test_h5read.R
@@ -202,15 +202,17 @@ h5File <- withr::local_tempfile(pattern = "ex_read", fileext = ".h5")
 
 h5createFile(h5File)
 
-test_that("NA characters are supported", {
+test_that("NA_character_ are supported and don't collide with the string 'NA'", {
   expect_silent(h5write(c(NA_character_, LETTERS), h5File, "NA_char"))
-  expect_true(anyNA(h5read(h5File, name = "NA_char")))
+  expect_identical(sum(is.na(h5read(h5File, name = "NA_char"))), 1L)
 
-  expect_warning(
-    h5write(c(NA_character_, LETTERS, "NA"), h5File, "NA_char_2"),
-    "Both NA_character_ and the string 'NA' detected",
-    fixed = TRUE
-  )
+  expect_silent(h5write(
+    c(NA_character_, LETTERS, "", "NA"),
+    h5File,
+    "NA_char_2"
+  ))
+  expect_identical(sum(is.na(h5read(h5File, name = "NA_char_2"))), 1L)
+  expect_identical(h5read(h5File, name = "NA_char_2")[29], "NA")
 })
 
 test_that("No warnings are generated for integers containing NA written from R", {

--- a/tests/testthat/test_h5write.R
+++ b/tests/testthat/test_h5write.R
@@ -272,3 +272,44 @@ test_that("Overwriting a subset", {
   expect_is(mat <- h5read(h5File, name = "matrix"), "matrix")
   expect_all_true(mat[, 2] == 0)
 })
+
+test_that("Writing a VLen string dataset with NA_character_ values", {
+  fid <- H5Fcreate(name = h5File)
+  expect_warning(
+    h5writeDataset(
+      obj = c(NA_character_, "NA", "", LETTERS),
+      h5loc = fid,
+      name = "vlen_string",
+      variableLengthString = TRUE,
+      # size should be ignored.
+      # See https://github.com/Huber-group-EMBL/rhdf5/issues/143.
+      size = 10
+    ),
+    "Argument `size` is ignored when `variableLengthString=TRUE`"
+  )
+  H5Fclose(fid)
+  fid <- H5Fopen(h5File)
+  did <- H5Dopen(fid, "vlen_string")
+  type <- H5Dget_type(did)
+  expect_true(H5Tis_variable_str(type))
+  H5Dclose(did)
+  H5Fclose(fid)
+
+  expect_type(vlen_string <- h5read(h5File, name = "vlen_string"), "character")
+  expect_identical(sum(is.na(vlen_string)), 1L)
+})
+
+test_that("Writing NA_character_ as fixed-length string is deprecated", {
+  fid <- H5Fcreate(name = h5File)
+  expect_warning(
+    h5writeDataset(
+      obj = c(NA_character_, "NA", "", LETTERS),
+      h5loc = fid,
+      name = "fixed_string",
+      variableLengthString = FALSE,
+      size = 10
+    ),
+    "Writing NA_character_ in fixed-length string datasets is fragile and deprecated"
+  )
+  H5Fclose(fid)
+})


### PR DESCRIPTION
As opposed to #209, this doesn't cause errors in h5py. It will just return an empty string (`""`).

- [ ] Deprecate the `"as.na"` attributes approach
- [ ] Warn if users try to write data with NA_character_ as fixed-length
- [ ] Investigate potential bug where `variableLengthString` might have been ignore if `!is.null(size)`
- [ ] Default to writing strings as VLen from all entry points