### PR TITLE
Restore as.na attribute for now

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rhdf5
 Title: R Interface to HDF5
-Version: 2.57.11
+Version: 2.57.12
 Authors@R: c(
     person("Bernd", "Fischer", role = "aut"),
     person("Mike", "Smith", role = "aut",

--- a/R/h5write.R
+++ b/R/h5write.R
@@ -405,8 +405,8 @@ h5writeDataset.array <- function(
     h5dataset <- H5Dopen(h5loc, name)
     on.exit(H5Dclose(h5dataset))
     type <- H5Dget_type(h5dataset)
-    is_vlen <- H5Tis_variable_str(type)
-    if (!is_vlen && anyNA(obj)) {
+    variableLengthString <- H5Tis_variable_str(type)
+    if (!variableLengthString && anyNA(obj)) {
       warning(
         "Writing NA_character_ in fixed-length string datasets is fragile ",
         "and deprecated.\n",
@@ -479,6 +479,11 @@ h5writeDataset.array <- function(
     count = count
   )
   h5writeAttribute(1L, h5dataset, name = "rhdf5-NA.OK")
+
+  if (!variableLengthString && anyNA(obj)) {
+    # THIS WILL BE REMOVED IN THE NEXT RELEASE!
+    h5writeAttribute(1L, h5dataset, name = "as.na")
+  }
 
   invisible(NULL)
 }

--- a/R/h5write.R
+++ b/R/h5write.R
@@ -411,7 +411,8 @@ h5writeDataset.array <- function(
         "Writing NA_character_ in fixed-length string datasets is fragile ",
         "and deprecated.\n",
         "In particular, it will write NA_character_ as the string 'NA' in ",
-        "the HDF5 file.\n"
+        "the HDF5 file.\n",
+        "Use variable-length strings instead."
       )
     }
   } else {


### PR DESCRIPTION
The goal is still to entirely drop support at the next release. But I see some issues in reverse dependencies and I'm taking it slower.